### PR TITLE
Add EF Core configs and seed data with Bogus

### DIFF
--- a/Infrastructure/YoutubeApi.Presistence/Configuration/BrandConfiguration.cs
+++ b/Infrastructure/YoutubeApi.Presistence/Configuration/BrandConfiguration.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YoutubeApi.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Bogus;
+
+
+namespace YoutubeApi.Presistence.Configuration
+{
+    public class BrandConfiguration : IEntityTypeConfiguration<Brand>
+    {
+        public void Configure(EntityTypeBuilder<Brand> builder)
+        {
+            builder.Property(x=> x.Name).HasMaxLength(50).IsRequired();
+
+            Faker faker = new ("tr");
+
+            Brand brand1 = new()
+            {
+                Id = 1,
+                Name = faker.Commerce.Department(),
+                CreatedDate = DateTime.Now,
+                IsDeleted = false
+
+            };
+            Brand brand2= new()
+            {
+                Id = 2,
+                Name = faker.Commerce.Department(),
+                CreatedDate = DateTime.Now,
+                IsDeleted = false
+
+            };
+            Brand brand3 = new()
+            {
+                Id = 3,
+                Name = faker.Commerce.Department(),
+                CreatedDate = DateTime.Now,
+                IsDeleted = true
+
+            };
+
+            builder.HasData(brand1,brand2,brand3);
+
+        }
+    }
+}

--- a/Infrastructure/YoutubeApi.Presistence/Configuration/CategoryConfiguration.cs
+++ b/Infrastructure/YoutubeApi.Presistence/Configuration/CategoryConfiguration.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YoutubeApi.Domain.Entities;
+
+namespace YoutubeApi.Presistence.Configuration
+{
+    public class CategoryConfiguration:IEntityTypeConfiguration<Category>
+    {
+        public void Configure(EntityTypeBuilder<Category> builder)
+        {
+            Category category1 = new()
+            {
+                Id = 1,
+                Name = "Elektrik",
+                Priorty = 1,
+                ParentId = 0,
+                IsDeleted = false,
+                CreatedDate = DateTime.Now,
+            };
+            Category category2 = new()
+            {
+                Id = 2,
+                Name = "Moda",
+                Priorty = 2,
+                ParentId = 0,
+                IsDeleted = false,
+                CreatedDate = DateTime.Now,
+            };
+
+            Category parent1 = new()
+            {
+                Id = 3,
+                Name = "Bilgisayar",
+                Priorty = 1,
+                ParentId = 1,
+                IsDeleted = false,
+                CreatedDate = DateTime.Now,
+            };
+
+            Category parent2 = new()
+            {
+                Id = 4,
+                Name = "Kadın",
+                Priorty = 1,
+                ParentId = 2,
+                IsDeleted = false,
+                CreatedDate = DateTime.Now,
+            };
+
+            builder.HasData(category1, category2, parent1, parent2);
+
+
+        }
+
+    }
+}

--- a/Infrastructure/YoutubeApi.Presistence/Configuration/DetailConfiguration.cs
+++ b/Infrastructure/YoutubeApi.Presistence/Configuration/DetailConfiguration.cs
@@ -1,0 +1,50 @@
+﻿using Bogus;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YoutubeApi.Domain.Entities;
+
+namespace YoutubeApi.Presistence.Configuration
+{
+    public class DetailConfiguration:IEntityTypeConfiguration<Detail>
+    {
+        public void Configure(EntityTypeBuilder<Detail> builder)
+        {
+            Faker faker = new("tr");
+
+            Detail detail1 = new()
+            {
+                Id = 1,
+                Title = faker.Lorem.Sentence(1),
+                Description = faker.Lorem.Sentence(5),
+                CategoryId = 1,
+                CreatedDate = DateTime.Now,
+                IsDeleted = false,
+            };
+            Detail detail2 = new()
+            {
+                Id = 2,
+                Title = faker.Lorem.Sentence(2),
+                Description = faker.Lorem.Sentence(5),
+                CategoryId = 3,
+                CreatedDate = DateTime.Now,
+                IsDeleted = true,
+            };
+            Detail detail3 = new()
+            {
+                Id = 3,
+                Title = faker.Lorem.Sentence(1),
+                Description = faker.Lorem.Sentence(5),
+                CategoryId = 4,
+                CreatedDate = DateTime.Now,
+                IsDeleted = false,
+            };
+
+            builder.HasData(detail1, detail2, detail3);
+        }
+    }
+}

--- a/Infrastructure/YoutubeApi.Presistence/Configuration/ProductConfiguration.cs
+++ b/Infrastructure/YoutubeApi.Presistence/Configuration/ProductConfiguration.cs
@@ -1,0 +1,45 @@
+﻿using Bogus;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YoutubeApi.Domain.Entities;
+
+namespace YoutubeApi.Presistence.Configuration
+{
+    public class ProductConfiguration : IEntityTypeConfiguration<Product>
+    {
+        public void Configure(EntityTypeBuilder<Product> builder)
+        {
+            Faker faker = new("tr");
+
+            Product product1 = new()
+            {
+                Id = 1,
+                Title = faker.Commerce.ProductName(),
+                Description = faker.Commerce.ProductDescription(),
+                BrandId = 1,
+                Discount = faker.Random.Decimal(0, 10),
+                Price = faker.Finance.Amount(10, 1000),
+                CreatedDate = DateTime.Now,
+                IsDeleted = false,
+            };
+            Product product2 = new()
+            {
+                Id = 2,
+                Title = faker.Commerce.ProductName(),
+                Description = faker.Commerce.ProductDescription(),
+                BrandId = 3,
+                Discount = faker.Random.Decimal(0, 10),
+                Price = faker.Finance.Amount(10, 1000),
+                CreatedDate = DateTime.Now,
+                IsDeleted = false,
+            };
+
+            builder.HasData(product1, product2);
+        }
+    }
+}

--- a/Infrastructure/YoutubeApi.Presistence/YoutubeApi.Presistence.csproj
+++ b/Infrastructure/YoutubeApi.Presistence/YoutubeApi.Presistence.csproj
@@ -6,4 +6,13 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="35.6.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\YoutubeApi.Domain\YoutubeApi.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/YoutubeApiSln.sln
+++ b/YoutubeApiSln.sln
@@ -9,15 +9,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Infrastructure", "Infrastru
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Presentation", "Presentation", "{0BD697D3-B224-4998-A3D7-ECD7EBCEE4A4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeApi.Application", "Core\YoutubeApi.Application\YoutubeApi.Application.csproj", "{09CDB912-D40E-4002-9E8C-6ADC72908855}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YoutubeApi.Application", "Core\YoutubeApi.Application\YoutubeApi.Application.csproj", "{09CDB912-D40E-4002-9E8C-6ADC72908855}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeApi.Domain", "Core\YoutubeApi.Domain\YoutubeApi.Domain.csproj", "{E1332649-AD5C-4B29-BE94-2512F6AA162B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YoutubeApi.Domain", "Core\YoutubeApi.Domain\YoutubeApi.Domain.csproj", "{E1332649-AD5C-4B29-BE94-2512F6AA162B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeApi.Infrastructure", "Infrastructure\YoutubeApi.Infrastructure\YoutubeApi.Infrastructure.csproj", "{F4A760AC-1962-4A81-AEF3-F8607283587F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YoutubeApi.Infrastructure", "Infrastructure\YoutubeApi.Infrastructure\YoutubeApi.Infrastructure.csproj", "{F4A760AC-1962-4A81-AEF3-F8607283587F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeApi.Presistence", "Infrastructure\YoutubeApi.Presistence\YoutubeApi.Presistence.csproj", "{2E6CBE4D-FC11-4872-9497-FFF57ECB97FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YoutubeApi.Presistence", "Infrastructure\YoutubeApi.Presistence\YoutubeApi.Presistence.csproj", "{2E6CBE4D-FC11-4872-9497-FFF57ECB97FC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeApi.Api", "Presantation\YoutubeApi.Api\YoutubeApi.Api.csproj", "{C7AAE21B-0011-4DA4-8E22-148627BCAE4B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YoutubeApi.Api", "Presantation\YoutubeApi.Api\YoutubeApi.Api.csproj", "{C7AAE21B-0011-4DA4-8E22-148627BCAE4B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Updated YoutubeApi.Presistence.csproj to include package references for Bogus (v35.6.0) and Microsoft.EntityFrameworkCore (v8.0.8), and added a project reference to YoutubeApi.Domain.csproj.

Added new configuration files in YoutubeApi.Presistence.Configuration namespace:
- BrandConfiguration.cs: Configures Brand entity, sets Name property constraints, and seeds data using Bogus.
- CategoryConfiguration.cs: Configures Category entity and seeds data.
- DetailConfiguration.cs: Configures Detail entity and seeds data using Bogus.
- ProductConfiguration.cs: Configures Product entity and seeds data using Bogus.