### PR TITLE
Add EF Core, project references, and repository interfaces

### DIFF
--- a/Core/YoutubeApi.Application/Interfaces/Repositories/IReadRepostory.cs
+++ b/Core/YoutubeApi.Application/Interfaces/Repositories/IReadRepostory.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using YoutubeApi.Domain.Common;
+using Microsoft.EntityFrameworkCore.Query;
+
+
+namespace YoutubeApi.Application.Interfaces.Repositories
+{
+    public interface IReadRepostory<T> where T : class,IEntityBase, new()
+    {
+        Task<IList<T>> GetAllAsync(Expression<Func<T, bool>>? predicate = null,
+           Func<IQueryable<T>, IIncludableQueryable<T, object>>? include = null,
+           Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null,
+           bool enableTracking = false);
+
+        Task<IList<T>> GetAllByPagingAsync(Expression<Func<T, bool>>? predicate = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>>? include = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null,
+            bool enableTracking = false, int currentPage = 1, int pageSize = 3);
+
+        Task<T> GetAsync(Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>>? include = null,
+            bool enableTracking = false);
+
+        IQueryable<T> Find(Expression<Func<T, bool>> predicate, bool enableTracking = false);
+
+        Task<int> CountAsync(Expression<Func<T, bool>>? predicate = null);
+    }
+}

--- a/Core/YoutubeApi.Application/Interfaces/Repositories/IWriteRepostory.cs
+++ b/Core/YoutubeApi.Application/Interfaces/Repositories/IWriteRepostory.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace YoutubeApi.Application.Interfaces.Repositories
+{
+    public interface IWriteRepostory
+    {
+    }
+}

--- a/Core/YoutubeApi.Application/YoutubeApi.Application.csproj
+++ b/Core/YoutubeApi.Application/YoutubeApi.Application.csproj
@@ -6,4 +6,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\YoutubeApi.Domain\YoutubeApi.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Infrastructure/YoutubeApi.Infrastructure/YoutubeApi.Infrastructure.csproj
+++ b/Infrastructure/YoutubeApi.Infrastructure/YoutubeApi.Infrastructure.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\YoutubeApi.Domain\YoutubeApi.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Infrastructure/YoutubeApi.Presistence/Registration.cs
+++ b/Infrastructure/YoutubeApi.Presistence/Registration.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using YoutubeApi.Application.Interfaces.Repositories;
 using YoutubeApi.Presistence.Context;
+using YoutubeApi.Presistence.Repositories;
 
 namespace YoutubeApi.Presistence
 {
@@ -15,6 +17,7 @@ namespace YoutubeApi.Presistence
         public static void AddPersistence(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddDbContext<AppDbContext>(opt =>opt.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
+            services.AddScoped(typeof(IReadRepostory<>), typeof(ReadRepository<>));
         }
     }
 }

--- a/Infrastructure/YoutubeApi.Presistence/Repositories/ReadRepository.cs
+++ b/Infrastructure/YoutubeApi.Presistence/Repositories/ReadRepository.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using YoutubeApi.Application.Interfaces.Repositories;
+using YoutubeApi.Domain.Common;
+
+namespace YoutubeApi.Presistence.Repositories
+{
+    public class ReadRepository<T> : IReadRepostory<T> where T : class, IEntityBase, new()
+    {
+        private readonly DbContext dbContext;
+
+        public ReadRepository(DbContext dbContext)
+        {
+            this.dbContext = dbContext;
+        }
+
+        private DbSet<T> Table { get => dbContext.Set<T>(); }
+
+        public async Task<IList<T>> GetAllAsync(Expression<Func<T, bool>>? predicate = null, Func<IQueryable<T>, IIncludableQueryable<T, object>>? include = null, Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null, bool enableTracking = false)
+        {
+            IQueryable<T> queryable = Table;
+            if (!enableTracking) queryable = queryable.AsNoTracking();
+            if (include is not null) queryable = include(queryable);
+            if (predicate is not null) queryable = queryable.Where(predicate);
+            if (orderBy is not null)
+                return await orderBy(queryable).ToListAsync();
+
+            return await queryable.ToListAsync();
+        }
+
+        public async Task<IList<T>> GetAllByPagingAsync(Expression<Func<T, bool>>? predicate = null, Func<IQueryable<T>, IIncludableQueryable<T, object>>? include = null, Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null, bool enableTracking = false, int currentPage = 1, int pageSize = 3)
+        {
+            IQueryable<T> queryable = Table;
+            if (!enableTracking) queryable = queryable.AsNoTracking();
+            if (include is not null) queryable = include(queryable);
+            if (predicate is not null) queryable = queryable.Where(predicate);
+            if (orderBy is not null)
+                return await orderBy(queryable).Skip((currentPage - 1) * pageSize).Take(pageSize).ToListAsync();
+
+            return await queryable.Skip((currentPage - 1) * pageSize).Take(pageSize).ToListAsync();
+        }
+
+        public async Task<T> GetAsync(Expression<Func<T, bool>> predicate, Func<IQueryable<T>, IIncludableQueryable<T, object>>? include = null, bool enableTracking = false)
+        {
+            IQueryable<T> queryable = Table;
+            if (!enableTracking) queryable = queryable.AsNoTracking();
+            if (include is not null) queryable = include(queryable);
+
+            //queryable.Where(predicate);
+
+            return await queryable.FirstOrDefaultAsync(predicate);
+        }
+
+        public async Task<int> CountAsync(Expression<Func<T, bool>>? predicate = null)
+        {
+            Table.AsNoTracking();
+            if (predicate is not null) Table.Where(predicate);
+
+            return await Table.CountAsync();
+        }
+
+        public IQueryable<T> Find(Expression<Func<T, bool>> predicate, bool enableTracking = false)
+        {
+            if (!enableTracking) Table.AsNoTracking();
+            return Table.Where(predicate);
+        }
+    }
+}

--- a/Infrastructure/YoutubeApi.Presistence/Repositories/WriteRepository.cs
+++ b/Infrastructure/YoutubeApi.Presistence/Repositories/WriteRepository.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace YoutubeApi.Presistence.Repositories
+{
+    public class WriteRepository
+    {
+    }
+}

--- a/Infrastructure/YoutubeApi.Presistence/YoutubeApi.Presistence.csproj
+++ b/Infrastructure/YoutubeApi.Presistence/YoutubeApi.Presistence.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Core\YoutubeApi.Application\YoutubeApi.Application.csproj" />
     <ProjectReference Include="..\..\Core\YoutubeApi.Domain\YoutubeApi.Domain.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- Added a reference to `Microsoft.EntityFrameworkCore` version `8.0.8` in `YoutubeApi.Application.csproj`.
- Added project references to `YoutubeApi.Domain` in `YoutubeApi.Application.csproj`, `YoutubeApi.Infrastructure.csproj`, and `YoutubeApi.Presistence.csproj`.
- Added a project reference to `YoutubeApi.Application` in `YoutubeApi.Presistence.csproj`.
- Updated `Registration.cs` to include the `YoutubeApi.Application.Interfaces.Repositories` namespace and register `ReadRepository` as a scoped service for `IReadRepostory`.
- Created the `IReadRepostory` interface in `IReadRepostory.cs` with methods for retrieving data from the database.
- Created the `IWriteRepostory` interface in `IWriteRepostory.cs` (currently empty).
- Implemented the `ReadRepository` class in `ReadRepository.cs` which provides concrete implementations for the methods defined in `IReadRepostory`.
- Created the `WriteRepository` class in `WriteRepository.cs` (currently empty).